### PR TITLE
Removed free monitoring for mongo

### DIFF
--- a/ansible/roles/mongodb-cluster/templates/mongod.conf.j2
+++ b/ansible/roles/mongodb-cluster/templates/mongod.conf.j2
@@ -106,7 +106,7 @@ operationProfiling:
   {% endfor %}
   {% endif %}
 
-{% if mongodb_major_version is version("4.0", ">=") -%}
+{# {% if mongodb_major_version is version("4.0", ">=") -%}
 cloud:
   monitoring:
     free:
@@ -116,7 +116,7 @@ cloud:
   {{ item }}
   {% endfor %}
   {% endif %}
-{% endif %}
+{% endif %} #}
 
 {% if mongodb_set_parameters -%}
 setParameter:


### PR DESCRIPTION
Free monitoring was decommissioned and removed from configuration on April 2023 for MongoDB Community instances. Commenting out because mongo service does not start due to invalid configuration.

Ref:  https://www.mongodb.com/docs/manual/release-notes/4.0/

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

- [x] Ran the pipeline Provision/Core/MongodbCluster and verified mongo service is installed as expected.